### PR TITLE
Fixes Bug with Multiple Instances and Adds Support for Multiple Filter Destinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ This module does support multiple instances, you can add as many entries for as 
 | `station`           | **Required** | String. The station you require information about. <br />This must be provided in the CRS format                                                          |
 | `token`             | **Required** | String. Your OpenLDBWS token - [obtained by registering here](http://realtime.nationalrail.co.uk/OpenLDBWSRegistration)                                   |
 | `columns`           | Optional     | Array. A list of columns that you wish to display. A list of these and their contents is given below                                                      |
-| `filterDestination` | Optional     | String. The CRS format code of a station, only departures that call here will be shown                                                                    |
+| `filterDestination` | Optional     | String or Array. The CRS format code of a station, only departures that call here will be shown                                                           |
 | `filterCancelled`   | Optional     | Boolean. Whether or not to filter out cancelled trains                                                                                                    |
 | `fetchRows`         | Optional     | Integer. The number of results to fetch in the OpenLDBWS query, before filtering (other than destination filtering, which is applied to the query itself) |
 | `displayRows`       | Optional     | Integer. The maximum number of results to display from the query result.                                                                                  |
@@ -62,6 +62,8 @@ You can configure the columns to display using the `columns` configuration optio
 | `status`        | Whether the train is On Time/Cancelled/Late                                                                               |
 | `dep_scheduled` | The scheduled departure time for this train                                                                               |
 | `dep_estimated` | The estimated departure time for this train                                                                               |
+| `eta`           | The estimated arrival time for this train at the first destination as set in filterDestination                            |
+| `duration`      | The estimated duration for this train between the origin and the first detination as set in the filterDestination         |
 
 ## OpenLDBWS Token
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ You can configure the columns to display using the `columns` configuration optio
 | `dep_scheduled` | The scheduled departure time for this train                                                                               |
 | `dep_estimated` | The estimated departure time for this train                                                                               |
 | `eta`           | The estimated arrival time for this train at the first destination as set in filterDestination                            |
-| `duration`      | The estimated duration for this train between the origin and the first detination as set in the filterDestination         |
+| `duration`      | The estimated duration for this train between the origin and the first destination as set in the filterDestination         |
 
 ## OpenLDBWS Token
 


### PR DESCRIPTION
This PR addresses a bug encountered when running multiple instances within MagicMirror, which resulted in all instances displaying the same output regardless of their configuration. The root cause of this issue was identified as the non-unique socket notifications for each instance. Consequently, when a socket notification was updated, it was erroneously picked up by all instances.

In addition to the bug fix, this update introduces support for multiple `filterDestination` from the same origin. This enhancement was implemented by adopting the `getDepartureBoardWithDetails` API, which includes detailed information about calling points in its response. The PR includes logic to filter the API response, identifying trains that match the specified destinations and calculating the estimated time of arrival (`eta`) and journey `duration` which are now available as columns. One drawback of this approach is the retrieval of irrelevant journeys. Given the API's limitation to a maximum of ten trains per request, this can sometimes result in less information being displayed on screen.

To mitigate this and maintain the original functionality, the PR retains the previous method for selecting a single `filterDestination`, which is directly added to the API request. This approach ensures that the core functionality is preserved while extending the capability for those requiring additional functionality. Furthermore, to ensure backward compatibility, the `filterDestination` parameter now accepts both a string and an array of strings.