### PR TITLE
Added first stop filtering

### DIFF
--- a/MMM-UKNationalRail.js
+++ b/MMM-UKNationalRail.js
@@ -21,6 +21,7 @@ Module.register("MMM-UKNationalRail", {
 
     filterDestination: [], // CRS code for station - only display departures calling here
     filterCancelled: false, // Filter out cancelled departures
+    filterFirstStop: [], // Filter for trains whose first stop is listed
 
     fetchRows: 20, // Maximum number of results to fetch (pre-filtering)
     displayRows: 10, // Maximum number of results to display (post-filtering)
@@ -179,6 +180,7 @@ Module.register("MMM-UKNationalRail", {
 
     this.trains = [];
     const { filterDestination } = this.config;
+    const { filterFirstStop } = this.config;
 
     if (filterDestination.length) {
       data = data.filter((entry) => {
@@ -187,6 +189,15 @@ Module.register("MMM-UKNationalRail", {
         );
       });
     }
+
+
+    if (filterFirstStop.length) {
+      data = data.filter((entry) => {
+        const firstCallingPoint = entry.subsequentCallingPoints[0];
+        return firstCallingPoint && filterFirstStop.includes(firstCallingPoint.crs);
+      });
+    }
+
 
     for (var entry in data) {
       // Stop processing if we've already reached the right number of rows to display
@@ -243,6 +254,7 @@ Module.register("MMM-UKNationalRail", {
         dep_scheduled: train.std,
         dep_estimated: train.etd,
         status: status,
+        first_stop: train.subsequentCallingPoints[0].locationName,
         eta,
         duration
       });

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ This module does support multiple instances, you can add as many entries for as 
 | `columns`           | Optional     | Array. A list of columns that you wish to display. A list of these and their contents is given below                                                      |
 | `filterDestination` | Optional     | String or Array. The CRS format code of a station, only departures that call here will be shown                                                           |
 | `filterCancelled`   | Optional     | Boolean. Whether or not to filter out cancelled trains                                                                                                    |
+| `filterFirstStop`   | Optional     | Array. CRS codes to filter for - only trains whose FIRST calling point matches - useful for excluding stopping services, for example                                                                                                     |
 | `fetchRows`         | Optional     | Integer. The number of results to fetch in the OpenLDBWS query, before filtering (other than destination filtering, which is applied to the query itself) |
 | `displayRows`       | Optional     | Integer. The maximum number of results to display from the query result.                                                                                  |
 
@@ -64,6 +65,7 @@ You can configure the columns to display using the `columns` configuration optio
 | `dep_estimated` | The estimated departure time for this train                                                                               |
 | `eta`           | The estimated arrival time for this train at the first destination as set in filterDestination                            |
 | `duration`      | The estimated duration for this train between the origin and the first destination as set in the filterDestination        |
+| `first_stop`      | The name of first calling point for the train        |
 
 ## OpenLDBWS Token
 


### PR DESCRIPTION
Added additional filter to permit trains to be filtered for their first calling point after the station.  This is helpful if you want to only report fast/direct services to particular destination and exclude stopping services.  

Equally, in some areas trains run in a loop e.g. Waterloo - Hounslow - Waterloo so the filter can be used to only include trains going in the desired direction.

first_stop column also added to table to display name of first stop. 